### PR TITLE
Remove duplicated folder "PHP"

### DIFF
--- a/src/org/netbeans/modules/php/blade/resources/Bundle.properties
+++ b/src/org/netbeans/modules/php/blade/resources/Bundle.properties
@@ -1,5 +1,5 @@
-text/x-blade=Blade Php
-text/blade-markup=Blade Php Markup
+text/x-blade=Blade PHP
+text/blade-markup=Blade PHP Markup
 OpenIDE-Module-Name=Blade for Netbeans
 
 OpenIDE-Module-Display-Category=PHP
@@ -12,7 +12,7 @@ OpenIDE-Module-Short-Description=Support for Blade template engine for PHP
 # import/export
 LBL_BladeExportName=Blade
 
-Loaders/text/x-blade/Factories/BladeDataLoader.instance=Blade Php Files
+Loaders/text/x-blade/Factories/BladeDataLoader.instance=Blade PHP Files
 Templates/Scripting/BladeTemplate.blade.php=Blade PHP file
 
 blade_comment = Comment
@@ -21,3 +21,4 @@ blade_echo= Variable Delimiter
 string = "string"
 blade_other = Error
 
+blade_template_displayName = Blade Template

--- a/src/org/netbeans/modules/php/blade/resources/package-info.java
+++ b/src/org/netbeans/modules/php/blade/resources/package-info.java
@@ -3,7 +3,11 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-@TemplateRegistration(folder = "PHP", content = "BladeTemplate.blade.php")
+@TemplateRegistration(
+        folder = "Scripting",
+        category = "PHP",
+        content = "BladeTemplate.blade.php",
+        displayName = "#blade_template_displayName")
 package org.netbeans.modules.php.blade.resources;
 
 import org.netbeans.api.templates.TemplateRegistration;


### PR DESCRIPTION
Add displayName property and fixed cases in bundle.properties

folder="PHP" is what I also expected but the folder is called "Scripting". Got them from the core code of NetBeans. This will remove the duplicated folder called PHP and add this to the original PHP folder. If the displayname is missing, NetBeans uses the filename which doesn't look nice in the wizard so I changed this in which I added the displayName.